### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@
 set(PROJECT_NAME Lab1)
 project (${PROJECT_NAME})
 
+# Choose vendor neutral OpenGL (libOpenGL.so, libGLX.so) over libGL.so
+cmake_policy(SET CMP0072 NEW)
+
 find_package(OpenGL REQUIRED)
 
 add_subdirectory(external/glad)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,4 +25,6 @@ target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 target_link_libraries(${PROJECT_NAME} PRIVATE glfw glad glm OpenGL::GL)
 target_include_directories(${PROJECT_NAME} PRIVATE "external" "external/include" "external/argparse/include")
 
+enable_testing()
+
 add_subdirectory(tests)

--- a/tests/RenderdocTest.cmake
+++ b/tests/RenderdocTest.cmake
@@ -1,4 +1,3 @@
-enable_testing()
 
 find_library(RENDERDOC_LIBRARY NAMES renderdoc REQUIRED)
 


### PR DESCRIPTION
This PR includes:
  - Setting CMake policy to use vendor-neutral OpenGL.
  - Move enable_testing CMake call to the root CMakeLists.txt